### PR TITLE
Fix cast bug with negative coordinates

### DIFF
--- a/src/cast/cast.c
+++ b/src/cast/cast.c
@@ -81,8 +81,8 @@ void	cast(t_cub3d *cub3d, t_vec2 pos, t_vec2 dir, t_hit *out)
 {
 	t_cast_state	state;
 
-	state.grid_x = pos.x;
-	state.grid_y = pos.y;
+	state.grid_x = floorf(pos.x);
+	state.grid_y = floorf(pos.y);
 	state.dir = dir;
 	state.distance_to_grid_x = cast_initial_distance_to_grid(pos.x, dir.x);
 	state.distance_to_grid_y = cast_initial_distance_to_grid(pos.y, dir.y);


### PR DESCRIPTION
Float to integer conversion rounds towards zero, so negative coordinates set the tile coordinate with an off-by-one error. In particular, both [0.0f, 1.0f) and (-1.0f, -0.0f] set the starting tile coordinate to 0 and map appears to shift when crossing the zero line. Use floor to round down and ensure the correct tile coordinate is selected.